### PR TITLE
Don't decamelize when slugifying

### DIFF
--- a/src/util/url-builder.js
+++ b/src/util/url-builder.js
@@ -4,7 +4,7 @@ import slugify from '@sindresorhus/slugify';
 export const filters = {
 	uppercase: (value) => value?.toUpperCase?.(),
 	lowercase: (value) => value?.toLowerCase?.(),
-	slugify,
+	slugify: (value) => slugify(value, { decamelize: false }),
 	year: (value) => value?.getFullYear?.(),
 	month: (value) => {
 		const month = value?.getMonth?.();

--- a/tests/generators/expected/custom-source.json
+++ b/tests/generators/expected/custom-source.json
@@ -87,7 +87,7 @@
       },
       {
         "date": "2020-07-28T00:00:00.000Z",
-        "title": "Effective upselling techniques",
+        "title": "Effective UpSelling techniques",
         "categories": [
           "sales",
           "tips"

--- a/tests/generators/expected/standard.json
+++ b/tests/generators/expected/standard.json
@@ -86,7 +86,7 @@
       },
       {
         "date": "2020-07-28T00:00:00.000Z",
-        "title": "Effective upselling techniques",
+        "title": "Effective UpSelling techniques",
         "categories": [
           "sales",
           "tips"

--- a/tests/generators/fixtures/standard/_posts/2016-07-28-effective-upselling-techniques.md
+++ b/tests/generators/fixtures/standard/_posts/2016-07-28-effective-upselling-techniques.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-07-28
-title: Effective upselling techniques
+title: Effective UpSelling techniques
 categories:
   - sales
   - tips

--- a/tests/util/url-builder.test.js
+++ b/tests/util/url-builder.test.js
@@ -9,7 +9,7 @@ const indexFilePath = 'content/pages/index.md';
 const data = {
 	id: 2,
 	date: new Date('2021-01-09T09:39:05.237Z'),
-	title: 'My Title!',
+	title: 'My TiTle!',
 	description: 'This is a longer than usual field'
 };
 
@@ -44,8 +44,8 @@ test('Replace index for file placeholders in URL template', (t) => {
 });
 
 test('Replace data placeholders in URL template', (t) => {
-	t.is(buildUrl(filePath, data, '/url/{title}'), '/url/My Title!');
-	t.is(buildUrl(filePath, data, '/url/{title}{id}'), '/url/My Title!2');
+	t.is(buildUrl(filePath, data, '/url/{title}'), '/url/My TiTle!');
+	t.is(buildUrl(filePath, data, '/url/{title}{id}'), '/url/My TiTle!2');
 });
 
 test('Replace data placeholders with filters in URL template', (t) => {


### PR DESCRIPTION
Currently CloudCannon's internal `slugify` functionality does not decamelize, while `reader` does:

```js
title = "My FooBar Page";

// CloudCannon page title, upload paths, etc
"{title|slugify}" => "my-foobar-page"

// Reader
"{title|slugify}" => "my-foo-bar-page"
```

This PR sets `decamelize` to `false` for our slugify functionality to match the platform behaviour. 