### PR TITLE
Fix an edge case when globbing the working dir

### DIFF
--- a/src/generators/collections.js
+++ b/src/generators/collections.js
@@ -15,7 +15,7 @@ async function getCollectionFilePaths(collectionConfig, source) {
 	// Work around for https://github.com/thecodrr/fdir/issues/92
 	// Globbing on `.` doesn't work, so we crawl using the absolute CWD
 	// and get the relative paths of results instead of the base paths.
-	if (crawlDirectory === '.' || crawlDirectory === './') {
+	if ((crawlDirectory === '.' || crawlDirectory === './') && collectionConfig.glob) {
 		crawler = crawler.withRelativePaths();
 		crawlDirectory = process.cwd();
 	}

--- a/src/generators/collections.js
+++ b/src/generators/collections.js
@@ -6,9 +6,19 @@ import log from '../util/logger.js';
 import { parseFile } from '../parsers/parser.js';
 
 async function getCollectionFilePaths(collectionConfig, source) {
-	const crawler = new fdir()
+	let crawler = new fdir()
 		.withBasePath()
 		.filter((filePath, isDirectory) => !isDirectory && !filePath.includes('/_defaults.'));
+
+	let crawlDirectory = join(source, collectionConfig.path);
+
+	// Work around for https://github.com/thecodrr/fdir/issues/92
+	// Globbing on `.` doesn't work, so we crawl using the absolute CWD
+	// and get the relative paths of results instead of the base paths.
+	if (crawlDirectory === '.' || crawlDirectory === './') {
+		crawler = crawler.withRelativePaths();
+		crawlDirectory = process.cwd();
+	}
 
 	const glob = typeof collectionConfig.glob === 'string'
 		? [collectionConfig.glob]
@@ -19,7 +29,7 @@ async function getCollectionFilePaths(collectionConfig, source) {
 	}
 
 	return crawler
-		.crawl(join(source, collectionConfig.path))
+		.crawl(crawlDirectory)
 		.withPromise();
 }
 

--- a/tests/generators/expected/root-glob.json
+++ b/tests/generators/expected/root-glob.json
@@ -1,0 +1,45 @@
+{
+  "source": ".",
+  "collections_config": {
+    "everything": {
+      "path": ".",
+      "glob": [
+        "tests/generators/fixtures/standard/**/nested/*"
+      ],
+      "output": true,
+      "url": "hello/{title|slugify}"
+    }
+  },
+  "_comments": {},
+  "_options": {},
+  "_structures": {},
+  "_select_data": {},
+  "generator": {},
+  "source_editor": {},
+  "paths": {
+    "uploads": "assets/uploads"
+  },
+  "base_url": "",
+  "time": "2000-11-22T00:00:00.000Z",
+  "cloudcannon": {
+    "name": "cloudcannon-reader",
+    "version": "0.0.1"
+  },
+  "version": "0.0.3",
+  "data": {},
+  "collections": {
+    "everything": [
+      {
+        "date": "2020-07-22T00:00:00.000Z",
+        "title": "Egg",
+        "categories": [
+          "tips"
+        ],
+        "author_staff_member": "betty",
+        "path": "tests/generators/fixtures/standard/_posts/nested/2020-07-22-egg.md",
+        "collection": "everything",
+        "url": "hello/egg"
+      }
+    ]
+  }
+}

--- a/tests/generators/fixtures/root-glob.json
+++ b/tests/generators/fixtures/root-glob.json
@@ -1,0 +1,23 @@
+{
+	"source": ".",
+	"collections_config": {
+		"everything": {
+			"path": ".",
+			"glob": [
+				"tests/generators/fixtures/standard/**/nested/*"
+			],
+			"output": true,
+			"url": "hello/{title|slugify}"
+		}
+	},
+	"_comments": {},
+	"_options": {},
+	"_structures": {},
+	"_select_data": {},
+	"generator": {},
+	"source_editor": {},
+	"paths": {
+		"uploads": "assets/uploads"
+	},
+	"base_url": ""
+}

--- a/tests/generators/info.test.js
+++ b/tests/generators/info.test.js
@@ -30,5 +30,6 @@ async function runTest(t, key) {
 test('Generate JSON info', async (t) => runTest(t, 'standard'));
 test('Generate JSON info with custom source', async (t) => runTest(t, 'custom-source'));
 test('Generate JSON info with globs', async (t) => runTest(t, 'globs'));
+test('Generate JSON info with a root glob', async (t) => runTest(t, 'root-glob'));
 test('Generate JSON info with null fields', async (t) => runTest(t, 'null-fields'));
 test('Generate JSON info with nested collections', async (t) => runTest(t, 'nested-collections'));


### PR DESCRIPTION
`cloudcannon.config.yml`
```yml
source: .
collections_config:
  docs:
    path: '.'
    glob: '**/*.md'
```

Currently this will return zero results (https://github.com/thecodrr/fdir/issues/92).

This PR adds a workaround for this one case:
https://github.com/CloudCannon/reader/blob/f667b6072729b11a1f8e14cfa1903dac1b789ce3/src/generators/collections.js#L15-L21