### PR TITLE
Update fdir and remove the glob workaround

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@sindresorhus/slugify": "^2.2.0",
         "chalk": "^5.2.0",
         "cosmiconfig": "^8.0.0",
-        "fdir": "^6.0.1",
+        "fdir": "^6.0.2",
         "gray-matter": "^4.0.3",
         "js-yaml": "^4.1.0",
         "meow": "^11.0.0",
@@ -1504,9 +1504,9 @@
       }
     },
     "node_modules/fdir": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.0.1.tgz",
-      "integrity": "sha512-bdrUUb0eYQrPRlaAtlSRoLs7sp6yKEwbMQuUgwvi/14TnaqhM/deSZUrC5ic+yjm5nEPPWE61oWpTTxQFQMmLA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.0.2.tgz",
+      "integrity": "sha512-XJVxBciDoEpRipMYyrTCqVQA4jMTfHNiYNy8OvIGTaQzEFPuMJEvmps+Rouo6rsnivkQax9s5m5gy1lHmY2Hmg==",
       "peerDependencies": {
         "picomatch": "2.x"
       },
@@ -4794,9 +4794,9 @@
       }
     },
     "fdir": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.0.1.tgz",
-      "integrity": "sha512-bdrUUb0eYQrPRlaAtlSRoLs7sp6yKEwbMQuUgwvi/14TnaqhM/deSZUrC5ic+yjm5nEPPWE61oWpTTxQFQMmLA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.0.2.tgz",
+      "integrity": "sha512-XJVxBciDoEpRipMYyrTCqVQA4jMTfHNiYNy8OvIGTaQzEFPuMJEvmps+Rouo6rsnivkQax9s5m5gy1lHmY2Hmg==",
       "requires": {}
     },
     "figures": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@sindresorhus/slugify": "^2.2.0",
     "chalk": "^5.2.0",
     "cosmiconfig": "^8.0.0",
-    "fdir": "^6.0.1",
+    "fdir": "^6.0.2",
     "gray-matter": "^4.0.3",
     "js-yaml": "^4.1.0",
     "meow": "^11.0.0",

--- a/src/generators/collections.js
+++ b/src/generators/collections.js
@@ -6,19 +6,11 @@ import log from '../util/logger.js';
 import { parseFile } from '../parsers/parser.js';
 
 async function getCollectionFilePaths(collectionConfig, source) {
-	let crawler = new fdir()
+	const crawler = new fdir()
 		.withBasePath()
 		.filter((filePath, isDirectory) => !isDirectory && !filePath.includes('/_defaults.'));
 
-	let crawlDirectory = join(source, collectionConfig.path);
-
-	// Work around for https://github.com/thecodrr/fdir/issues/92
-	// Globbing on `.` doesn't work, so we crawl using the absolute CWD
-	// and get the relative paths of results instead of the base paths.
-	if ((crawlDirectory === '.' || crawlDirectory === './') && collectionConfig.glob) {
-		crawler = crawler.withRelativePaths();
-		crawlDirectory = process.cwd();
-	}
+	const crawlDirectory = join(source, collectionConfig.path);
 
 	const glob = typeof collectionConfig.glob === 'string'
 		? [collectionConfig.glob]


### PR DESCRIPTION
Follow-up to #3 

- Updates fdir to `6.0.2`
- Removes the workaround for thecodrr/fdir#92